### PR TITLE
Add default block parameter to eth_call

### DIFF
--- a/lib/web3/eth/contract.rb
+++ b/lib/web3/eth/contract.rb
@@ -6,7 +6,7 @@ module Web3
       include Abi::Utils
       include Utility
 
-      
+
       class ContractInstance
 
         def initialize contract, address
@@ -63,7 +63,7 @@ module Web3
 
         data = '0x' + function.signature_hash + encode_hex(encode_abi(function.input_types, args) )
 
-        response = web3_rpc.request "eth_call", [{ to: contract_address, data: data}]
+        response = web3_rpc.request "eth_call", [{ to: contract_address, data: data}, 'latest']
 
         string_data = [remove_0x_head(response)].pack('H*')
         return nil if string_data.empty?

--- a/lib/web3/eth/rpc.rb
+++ b/lib/web3/eth/rpc.rb
@@ -43,10 +43,15 @@ module Web3
 
           raise "Error code #{response.code} on request #{@uri.to_s} #{request.body}" unless response.kind_of? Net::HTTPOK
 
-          json = JSON.parse(response.body)['result']
-          raise "No response on request #{@uri.to_s} #{request.body}" unless json
+          body = JSON.parse(response.body)
 
-          json
+          if body['result']
+            body['result']
+          elsif body['error']
+            raise "Error #{@uri.to_s} #{body['error']} on request #{@uri.to_s} #{request.body}"
+          else
+            raise "No response on request #{@uri.to_s} #{request.body}"
+          end
 
         end
 


### PR DESCRIPTION
https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_call
https://github.com/ethereum/go-ethereum/issues/2472

Looks like some rpc implementations require the default block parameter. 

Thanks for this gem!