### PR TITLE
Hash#compact support for ruby versions less than 2.4.0

### DIFF
--- a/lib/web3/eth/rpc.rb
+++ b/lib/web3/eth/rpc.rb
@@ -61,3 +61,11 @@ module Web3
     end
   end
 end
+
+unless Hash.method_defined?(:compact)
+  class Hash
+    def compact
+      self.reject{ |_k, v| v.nil? }
+    end
+  end
+end


### PR DESCRIPTION
without using Rails and for versions less then 2.4.0
>   web3.eth.getBalance('0x...')
NoMethodError: undefined method `compact' for #<Hash:...>