### PR TITLE
BUG FIX: provide nil check in `Transaction#block_number`

### DIFF
--- a/lib/web3/eth/transaction.rb
+++ b/lib/web3/eth/transaction.rb
@@ -36,7 +36,9 @@ module Web3
       end
 
       def block_number
-        from_hex blockNumber
+        # if transaction is less than 12 seconds old, blockNumber will be nil
+        # :. nil check before calling `to_hex` to avoid argument error
+        blockNumber && from_hex(blockNumber)
       end
 
       def value_wei


### PR DESCRIPTION
* **BUG:** calling `#block_number` on a transaction that has just been created but not yet committed to the blockchain causes `Utility#from_hex` to raise an argument error exception
* **CAUSE:** because the transaction is new, its `blockNumber` value is `nil`, thus when I try to call `from_hex` `#to_i` is called on `nil`, which raises an exception
* **FIX:** provide a nil check in `Transaction#block_number` to avoid calling `Utility#from_hex` if `blockNumber` is nil and instead return `nil`

**NOTE:**
* I have confirmed that this works locally, but have not provided a test for the patch, as the test harness for the project appears to be skeletal at the moment. Happy to provide one with guidance from upstream folks if the lack of testing is a blocker to merging.