### PR TITLE
Fix getBlockByNumber "undefined method `each' for String" error when full is false

### DIFF
--- a/lib/web3/eth/block.rb
+++ b/lib/web3/eth/block.rb
@@ -7,7 +7,7 @@ module Web3
 
       attr_reader :raw_data
 
-      def initialize block_data
+      def initialize block_data, full = true
         @raw_data = block_data
 
         block_data.each do |k, v|
@@ -15,7 +15,9 @@ module Web3
           self.class.send(:define_method, k, proc {self.instance_variable_get("@#{k}")})
         end
 
-        @transactions = @transactions.collect {|t|  Web3::Eth::Transaction.new t }
+        if full
+          @transactions = @transactions.collect {|t|  Web3::Eth::Transaction.new t }
+        end
 
       end
 

--- a/lib/web3/eth/eth_module.rb
+++ b/lib/web3/eth/eth_module.rb
@@ -18,7 +18,7 @@ module Web3
 
       def getBlockByNumber block, full = true, convert_to_object = true
         resp = @web3_rpc.request("#{PREFIX}#{__method__}", [hex(block), full])
-        convert_to_object ? Block.new(resp, full=full) : resp
+        convert_to_object ? Block.new(resp, full = full) : resp
       end
 
       def blockNumber

--- a/lib/web3/eth/eth_module.rb
+++ b/lib/web3/eth/eth_module.rb
@@ -18,7 +18,7 @@ module Web3
 
       def getBlockByNumber block, full = true, convert_to_object = true
         resp = @web3_rpc.request("#{PREFIX}#{__method__}", [hex(block), full])
-        convert_to_object ? Block.new(resp) : resp
+        convert_to_object ? Block.new(resp, full=full) : resp
       end
 
       def blockNumber


### PR DESCRIPTION
## Description of the problem

When trying to call
```
@web3.eth.getBlockByNumber(3000000, full=false)
```

It returns error
```
NoMethodError (undefined method `each' for #<String:0x0000556be1cd9c20>)
```

## Clause of problem

`Block` constructor attempts to convert each element in the array of transaction `@transactions` to `Transaction` objects. When `full` is `false`, `@transactions` is an array of transaction hashes string, and cause the error.

## What I think is the correct behaviour?

It should not try to instantiate a `Transaction` but to leave the array of transaction hashes untouched.

-----

p.s. This is my first time creating PR on other developer's repository and I am quite new to Ruby. Please let me know if I made something wrong and I am always willing to learn. Thank you.