### PR TITLE
Support call functions at block number

### DIFF
--- a/lib/web3/eth/contract.rb
+++ b/lib/web3/eth/contract.rb
@@ -82,9 +82,10 @@ module Web3
         end
 
         def do_call web3_rpc, contract_address, args
-          data = '0x' + signature_hash + encode_hex(encode_abi(input_types, args) )
+          blockno = args[-1] || "latest"
+          data = '0x' + signature_hash + encode_hex(encode_abi(input_types, args - [blockno]))
 
-          response = web3_rpc.request "eth_call", [{ to: contract_address, data: data}, 'latest']
+          response = web3_rpc.request "eth_call", [{ to: contract_address, data: data}, blockno]
 
           string_data = [remove_0x_head(response)].pack('H*')
           return nil if string_data.empty?


### PR DESCRIPTION
Pass BlockNumber value at the last of params list.
Ex: 
```
# creation of contract object
myContract = web3.eth.contract(abi);

# initiate contract for an address
myContractInstance = myContract.at('0x2ad180cbaffbc97237f572148fc1b283b68d8861');

# call constant function at block_number
result = myContractInstance.balanceOf([address], [block_number]); 
puts result 
```