### PR TITLE
Readme-fix: fixed incorrect rpc_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ web3 = Web3::Eth::Rpc.new host: 'mainnet.infura.io',
                             open_timeout: 20,
                             read_timeout: 140,
                             use_ssl: true,
-                            rpc_path: '/<YOUR INFURA PERSONAL KEY>'
+                            rpc_path: '/v3/<YOUR INFURA PERSONAL KEY>'
                           }
 ```
 


### PR DESCRIPTION
The rpc_path mentioned in the readme file is throwing 403 error. I have updated it with the correct path.